### PR TITLE
Add arg to groupBy

### DIFF
--- a/controllers/Statistics.php
+++ b/controllers/Statistics.php
@@ -72,7 +72,7 @@ class Statistics extends Controller
             ->join('offline_indirect_redirects AS r', 'r.id', '=', 'redirect_id')
             ->whereMonth('timestamp', '=', date('m'))
             ->whereYear('timestamp', '=', date('Y'))
-            ->groupBy('redirect_id')
+            ->groupBy('redirect_id', 'r.from_url')
             ->orderByRaw('hits DESC')
             ->limit(10)
             ->get()


### PR DESCRIPTION
Using this plugin with PostgresQL, I got the following exception:

```
SQLSTATE[42803]: Grouping error: 7 ERROR: column "r.from_url" must appear in the GROUP BY clause or be used in an aggregate function LINE 1: select COUNT(redirect_id) AS hits, "redirect_id", "r"."from_... ^ (SQL: select COUNT(redirect_id) AS hits, "redirect_id", "r"."from_url" from "offline_indirect_clients" inner join "offline_indirect_redirects" as "r" on "r"."id" = "redirect_id" where extract(month from "timestamp") = 02 and extract(year from "timestamp") = 2018 group by "redirect_id" order by hits DESC limit 10)
```

Adding `r.from_url` to `groupBy` fixed the error.

You can see they made [a similar change upstream](https://github.com/adrenth/redirect/blob/develop/classes/StatisticsHelper.php#L182).

**I have not tested this extensively.** It's working on our project using PostgresQL 10.1 and PHP 7.1.14.